### PR TITLE
Criação de configuraçao de http client global para o realize

### DIFF
--- a/src/js/components/grid/grid.js
+++ b/src/js/components/grid/grid.js
@@ -8,7 +8,7 @@ import { isEmpty } from 'lodash';
 
 import PropTypes from '../../prop_types';
 import Realize from '../../realize';
-import RestClient from '../../services/rest_client';
+import { RestClient } from '../../services/http';
 import I18n from '../../i18n';
 
 import {

--- a/src/js/init/config.js
+++ b/src/js/init/config.js
@@ -1,3 +1,4 @@
+import { defaultHttpClient } from '../services/http'
 
 export default {
   restUrls: {
@@ -19,6 +20,8 @@ export default {
     update: 'PUT',
     destroy: 'DELETE',
   },
+
+  httpClient: defaultHttpClient,
 
   grid: {
     pagination: {

--- a/src/js/services/http/default_http_client.js
+++ b/src/js/services/http/default_http_client.js
@@ -1,0 +1,11 @@
+import $ from 'jquery';
+
+export default (url, options) => new Promise((resolve, reject) => {
+      $.ajax({
+        url,
+        ...options,
+        method: options.method || 'GET',
+        success: resolve,
+        error: reject,
+      });
+    });

--- a/src/js/services/http/http_options.js
+++ b/src/js/services/http/http_options.js
@@ -1,0 +1,26 @@
+export default class HttpOptions {
+    constructor(url, headers = {}, method = {}, data = {}, customOptions = {}){
+        this.url = url;
+        this.headers = headers;
+        this.method = method;
+        this.data = data;
+        this.customOptions = customOptions;
+    }
+    get url(){
+        this.url;
+    }
+    get headers(){
+        this.headers;
+    }
+    get method(){
+        this.method;
+    }
+
+    get data(){
+        this.data;
+    }
+
+    get customOptions(){
+        this.customOptions;
+    }
+};

--- a/src/js/services/http/index.js
+++ b/src/js/services/http/index.js
@@ -1,0 +1,3 @@
+export { default as RestClient } from './rest_client';
+export { default as defaultHttpClient } from './default_http_client';
+export { default as HttpOptions } from './http_options';

--- a/src/js/services/http/rest_client.js
+++ b/src/js/services/http/rest_client.js
@@ -1,13 +1,12 @@
 // TODO: mudar jQuery.ajax para client rest
-import Realize from '../realize';
-import $ from 'jquery';
+import Realize from '../../realize';
 import { merge } from 'lodash';
+import { extractQueryString, removeQueryString } from '../../utils/url'
 
 export default class RestClient {
   constructor(options) {
     this.options = options;
     this.config = Realize.config;
-
     this.configureActions(this.actionNames);
   }
 
@@ -28,25 +27,20 @@ export default class RestClient {
   }
 
   request(url, method, data, options = {}) {
-    return new Promise((resolve, reject) => {
-      $.ajax({
-        method,
-        data,
-        url,
-        ...options,
-        success: resolve,
-        error: reject,
-      });
-    });
+    return Realize.config.httpClient(url, this.mergeRequestParameters(method, data, options));
+  }
+
+  mergeRequestParameters(method, data, options = {}){
+    return merge({}, options, {method, data});
   }
 
   getRestActionUrl(action, id) {
     const actionUrl = this.actionUrls[action];
-    const actionBaseUrl = this.getActionBaseUrl();
-    const actionQueryString = this.getActionQueryString();
+    const actionBaseUrl = removeQueryString(this.baseUrl);
+    const actionQueryString = extractQueryString(this.baseUrl);
 
     const argsRegEx = id ? /:id/ : /:url/;
-    const value = id || actionBaseUrl;
+    const value = id || actionBaseUrl;  
 
     const replacedActionUrl = actionUrl.replace(argsRegEx, value);
     return replacedActionUrl + actionQueryString;
@@ -77,15 +71,5 @@ export default class RestClient {
       enumerable: true,
       writable: false,
     });
-  }
-
-  getActionBaseUrl() {
-    const matches = this.baseUrl.match(/^(.*)\?/);
-    return matches ? matches[1] : this.baseUrl;
-  }
-
-  getActionQueryString() {
-    const matches = this.baseUrl.match(/\?.*$/);
-    return matches ? matches[1] : '';
   }
 }

--- a/src/js/utils/url.js
+++ b/src/js/utils/url.js
@@ -1,0 +1,9 @@
+export const extractQueryString = (url) => {
+    const matches = url.match(/\?.*$/);
+    return matches ? matches[0] : '';
+}
+
+export const removeQueryString = (url) => {
+    const matches = url.match(/^(.*)\?/);
+    return matches ? matches[1] : url;
+}

--- a/test/specs/services/http/rest_client.spec.js
+++ b/test/specs/services/http/rest_client.spec.js
@@ -1,0 +1,68 @@
+import Realize from 'realize';
+import { RestClient, defaultHttpClient } from 'services/http'
+
+describe('rest_client', () => {
+    let restClient;
+    const httpClientStub = sinon.stub(Realize.config, 'httpClient');
+    const defaultMethod = 'GET';
+    const defaultData = { customData: 'teste' };
+    const defaultMergedParameters = {
+        method: defaultMethod,
+        data: defaultData
+    };
+    beforeEach(() => {
+        restClient = new RestClient({})
+        Realize.config.httpClient = httpClientStub;
+    });
+
+    describe('#constructor', () => {
+        it('must receive an options object', () => {
+            
+        })
+    });
+    
+    describe('#request', () => {
+        let mergeRequestParametersStub;
+        beforeEach(() => mergeRequestParametersStub = sinon.stub(restClient, 'mergeRequestParameters'));
+        it('should call default http client when config not set', () => {
+            restClient.request();
+            expect(httpClientStub).to.be.calledOnce;
+        });
+
+        it('should call custom http client when set', () => {
+            const customHttpClient = sinon.stub();
+            Realize.config.httpClient = customHttpClient;
+            restClient.request();
+            expect(customHttpClient).to.be.calledOnce;
+        });
+
+        it('should call with merged parameters and url', () => {
+            let url = 'url';
+            let defaultOptions = {};
+            mergeRequestParametersStub.withArgs(defaultMethod, defaultData, defaultOptions).returns(defaultMergedParameters);
+            restClient.request(url, defaultMethod, defaultData, defaultOptions);
+            expect(httpClientStub).to.have.been.calledWith(url, defaultMergedParameters);
+        });
+    });
+
+    describe('#mergeRequestParameters', () => {
+        it('should merge the parameters without options', () => {
+            const result = restClient.mergeRequestParameters(defaultMethod, defaultData);
+            expect(result).to.be.eql({
+                method: defaultMethod,
+                data: defaultData
+            });
+        });
+
+        it('should merge the parameters with options', () => {
+            const customOptions = { testOption: 'test' };
+            const result = restClient.mergeRequestParameters(defaultMethod, defaultData, customOptions);
+            expect(result).to.be.eql({
+                method: defaultMethod,
+                data: defaultData,
+                testOption: 'test'
+            });
+        });
+    });
+    
+});

--- a/test/specs/utils/url.spec.js
+++ b/test/specs/utils/url.spec.js
@@ -1,0 +1,33 @@
+import { removeQueryString, extractQueryString } from 'utils/url'
+
+describe('utils.url', () => {
+    describe('#extractQueryString', () => {
+        it('should extract query string from valid url', () => {
+            const queryString = '?valid=true';
+            const url = `http://localhost/app${queryString}`;
+            const result = extractQueryString(url);
+            expect(result).to.be.eql(queryString);
+        });
+
+        it('should return empty with non query string url', () => {
+            const url = `http://localhost/app`;
+            const result = extractQueryString(url);
+            expect(result).to.be.eql('');
+        });
+    })
+
+    describe('#removeQueryString', () => {
+        it('should remove query string from a url with query string', () => {
+            const baseUrl = 'localhost/app';
+            const url = `http://${baseUrl}?queryString`;
+            const result = removeQueryString(baseUrl);
+            expect(result).to.be.eql(baseUrl);
+        });
+
+        it('should return the same url from a url without query string', () => {
+            const url = `http://localhost/`;
+            const result = removeQueryString(url);
+            expect(result).to.be.eql(url);
+        });
+    })
+})


### PR DESCRIPTION
Eu criei essa configuração para permitir extensão e interceptação de todas as chamadas http que o realize fizer. É possível decorar o método responsável por fazer essa chamada injetando qualquer options na chamada assim.
Ex:

```
import { config } from 'realizejs';
let defaultHttpClient = config.httpClient;
config.httpClient = (url, options) => {
  console.log("Logging");
  options.headers = {
    "TenantId": "Teste"
  };
 return defaultHttpClient(url, options);
} 
```

Eu simplifiquei essa chamada também para apenas receber url e options, cabendo ao RestClient realizar a concatenação dessas paramêtros. Também fiz uma pequena mudança de package do RestClient de /services para /services/http