### PR TITLE
Formulário com input datepicker apresenta erro ao enviar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realizejs",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "description": "A rich set of UI components based on Material Design using React.js",
   "authors": [
     "Ariel Lindgren <ariel@wkm.com.br>",

--- a/src/js/components/input/input_datepicker.js
+++ b/src/js/components/input/input_datepicker.js
@@ -29,6 +29,7 @@ export default class InputDatepicker extends InputBase {
     format: null,
     maskType: 'date',
     calendar: true,
+    visible: true
   };
 
   state = {
@@ -91,6 +92,7 @@ export default class InputDatepicker extends InputBase {
 
   @autobind
   setPickadatePlugin() {
+    const self = this;
     const $inputNode = $(ReactDOM.findDOMNode(this.refs.input)).pickadate({
       editable: true,
       selectMonths: true,
@@ -131,7 +133,7 @@ export default class InputDatepicker extends InputBase {
       : '';
 
     $(ReactDOM.findDOMNode(this.refs.input)).pickadate('close');
-    this.setState({ inputMaskedKey: this.generateUUID(), value });
+    this.setState({ inputMaskedKey: uuid.v4(), value });
   }
 
   @autobind


### PR DESCRIPTION
## Problema

Enviar um formulário definido com um _InputDatepicker_ está apresentando erro no método _InputDatepicker#setPickadatePlugin_

## Resolução:

- Configurar prop default visible como true
- Corrigir escopo da função do _onOpen_ para o plugin do Pickadate