### PR TITLE
Corrigido ação de limpar componente InputDatepicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![alt tag](https://working-minds.github.io/realizejs/assets/img/content/realizejs.png)
 
-### Current version: 0.9.20 beta
+### Current version: 0.9.21 beta
 
 Read the documentation on how to get started on [Realize.js](https://working-minds.github.io/realizejs/en)

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "realizejs",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "authors": [
     "Ariel Lindgren <ariel@wkm.com.br>",
     "Pedro Jesus <pjesus@wkm.com.br>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realizejs",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "description": "A rich set of UI components based on Material Design using React.js",
   "authors": [
     "Ariel Lindgren <ariel@wkm.com.br>",

--- a/src/js/components/input/input_datepicker.js
+++ b/src/js/components/input/input_datepicker.js
@@ -42,8 +42,16 @@ export default class InputDatepicker extends InputBase {
     this.setPickadatePlugin();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(_, state) {
     this.setPickadatePlugin();
+    if (!this.state.value && !!this.state.value !== !!state.value) {
+      this.clearPickadate();
+    }
+  }
+
+  clearPickadate() {
+    const picker = $(ReactDOM.findDOMNode(this.refs.input)).pickadate('picker');
+    if (picker && picker.clear) picker.clear();
   }
 
   getDateFormat() {


### PR DESCRIPTION
## Problema

InputDatepicker não limpa valor quando a prop value do componente é configurada para null

## Resolução

- Após configurar o plugin pickadate, verificar se o value é _falsey_ e chamar `picker.clear()`