### PR TITLE
Adicionado `event.preventDefault()` ao clicar em item da paginação

### DIFF
--- a/src/js/components/pagination/pagination_item.js
+++ b/src/js/components/pagination/pagination_item.js
@@ -67,8 +67,9 @@ export default class PaginationItem extends Component {
     return themeClassKey;
   }
 
-  handleClick = () => {
-    if(!this.props.disabled) {
+  handleClick = (event) => {
+    event.preventDefault();
+    if (!this.props.disabled) {
       this.props.onClick();
     }
   }


### PR DESCRIPTION
## Problema

Clicar em item de paginação, link abria nova aba.

## Solução

- Adicionar `event.preventDefault()` no _PaginationItem#handleClick()_