### PR TITLE
Form apresenta erro quando componente InputGroup não está montado

### DIFF
--- a/src/js/components/form/form.js
+++ b/src/js/components/form/form.js
@@ -123,6 +123,8 @@ export default class Form extends Component {
 
   validate(event, postData) {
     const inputGroup = this.refs.inputGroup;
+    if (!inputGroup) return;
+
     const validationErrors = inputGroup.validate();
     if (!_.isEmpty(validationErrors)) {
       this.props.onValidationErrors(validationErrors, postData);
@@ -146,17 +148,15 @@ export default class Form extends Component {
     event.persist();
     const postData = this.serialize();
 
-    return Promise.resolve()
-      .then(() => this.props.onSubmit(event, postData))
-      .then(() => this.validate(event, postData))
-      .then(() => {
-        FormActions.submit(this.props.id, event, postData);
+    this.validate(event, postData);
+    this.props.onSubmit(event, postData);
 
-        if (!event.isDefaultPrevented()) {
-          this.setState({ isLoading: true, errors: [], showSuccessFlash: false });
-          this.submit(postData);
-        }
-      });
+    FormActions.submit(this.props.id, event, postData);
+
+    if (!event.isDefaultPrevented()) {
+      this.setState({ isLoading: true, errors: [], showSuccessFlash: false });
+      this.submit(postData);
+    }
   }
 
   submit(postData) {

--- a/test/specs/form/form.spec.js
+++ b/test/specs/form/form.spec.js
@@ -1,51 +1,85 @@
 import React from 'react'
 import $ from 'jquery'
 import Realize from 'realize'
-import { Form } from 'components/form'
-import { assert } from 'chai';
-import { shallow } from 'enzyme';
+import Form from 'components/form/form';
+import InputGroup from 'components/form/input_group';
+import Input from 'components/input/input';
+import {assert} from 'chai';
+import {shallow, mount} from 'enzyme';
+import Chance from 'chance';
+
+const chance = new Chance();
 
 describe('<Form/>', () => {
-  it('exists', () => {
-    assert(Form);
+  it('renders a form', () => {
+    const content = shallow(<Form />);
+    expect(content.find('form').exists()).to.be.true;
   });
-  it('renders with the default props', () => {
-    const content = shallow(
-      <Form />
-    );
-    assert(content.find('Form'));
+
+  describe('validation', function() {
+    beforeEach(function() {
+      this.sandbox = sinon.sandbox.create();
+
+      this.inputName = chance.md5();
+      this.inputErrors = [chance.md5()];
+      this.postData = { [this.inputName]: chance.md5() };
+      this.validationErrors = { [this.inputName]: this.inputErrors };
+
+      this.validationCallback = sinon.spy();
+      this.submitCallback = sinon.spy();
+
+      this.event = {
+        nativeEvent: { preventDefault: sinon.spy() },
+        preventDefault: sinon.spy(),
+        persist: sinon.spy(),
+      };
+    });
+
+    afterEach(function() {
+      this.sandbox.restore();
+    });
+
+    it('applies validation when InputGroup is mounted', function() {
+      this.sandbox
+        .stub(InputGroup.prototype, 'validate')
+        .returns(this.validationErrors);
+
+      this.sandbox.stub(Form.prototype, 'submit');
+      this.sandbox.stub(Form.prototype, 'serialize').returns(this.postData);
+
+      const content = mount(
+        <Form
+          onValidationErrors={this.validationCallback}
+          onSubmit={this.submitCallback}
+          inputs={{ [this.inputName]: { component: 'text' } }}
+        />
+      );
+
+      content.find('form').simulate('submit', this.event);
+
+      expect(this.submitCallback).to.have.been.called;
+      expect(this.event.preventDefault).to.have.been.called;
+      expect(this.validationCallback).to.have.been.calledWith(this.validationErrors, this.postData);
+    });
+
+    it('ignores validation when InputGroup is not mounted', function() {
+      this.sandbox.stub(Form.prototype, 'submit');
+      this.sandbox.stub(Form.prototype, 'serialize').returns(this.postData);
+
+      const content = mount(
+        <Form
+          onValidationErrors={this.validationCallback}
+          onSubmit={this.submitCallback}
+        >
+          <Input component="text" name={this.inputName} />
+        </Form>
+      );
+
+      content.find('form').simulate('submit', this.event);
+
+      expect(this.submitCallback).to.have.been.called;
+      expect(this.validationCallback).to.not.have.been.called;
+    });
   });
-  it('renders with isLoading', () => {
-    const content = shallow(
-      <Form
-            isLoading
-      />
-    );
-    assert(content.find('isLoading'));
-  });
-  it('renders with otherButtons', () => {
-    const content = shallow(
-      <Form
-           otherButtons= {[
-               {
-                   name: 'actions.clear',
-                   icon: 'delete',
-                   element: 'button',
-                   type: 'reset'
-               }
-           ]}
-       />
-    );
-    assert(content.find('otherButtons'));
-  });
-  it('renders with onSubmit', () => {
-    const content = shallow(
-      <Form
-        onSubmit={function(){
-         alert('Product Created')
-         }}
-       />
-    );
-    assert(content.find('onSubmit'));
-  });
+
 });


### PR DESCRIPTION
## Problema

Ao enviar formulário, se não houver referência para InputGroup, o Form lança uma exceção `validate of undefined`.

## Solução

- Antes de executar a validação, verificar se existe referência para o componente InputGroup

## Futuras melhorias

- Extrair lógica de validação para camada externa ao componente