### PR TITLE
Corrigido referências ao PropTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![alt tag](https://working-minds.github.io/realizejs/assets/img/content/realizejs.png)
 
-### Current version: 0.9.24 beta
+### Current version: 0.9.25 beta
 
 Read the documentation on how to get started on [Realize.js](https://working-minds.github.io/realizejs/en)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realizejs",
-  "version": "0.9.24",
+  "version": "0.9.25",
   "description": "A rich set of UI components based on Material Design using React.js",
   "authors": [
     "Ariel Lindgren <ariel@wkm.com.br>",
@@ -74,6 +74,7 @@
     "materialize-css": "^0.97.6",
     "moment": "^2.12.0",
     "numeral": "^2.0.4",
+    "prop-types": "^15.6.1",
     "react": "^0.14.7",
     "react-addons-css-transition-group": "^0.14.7",
     "react-color": "^1.3.7",

--- a/src/js/components/card/card.js
+++ b/src/js/components/card/card.js
@@ -4,7 +4,7 @@ import PropTypes from '../../prop_types';
 export default class Card extends Component {
   static propTypes = {
     children: PropTypes.oneOfType([
-      PropTypes.arrayOf(React.PropTypes.node),
+      PropTypes.arrayOf(PropTypes.node),
       PropTypes.node,
     ]),
   };

--- a/src/js/components/form/input_group.js
+++ b/src/js/components/form/input_group.js
@@ -24,7 +24,7 @@ export default class InputGroup extends Component {
     wrapperClassName: PropTypes.string,
     inputWrapperComponent: PropTypes.component,
     children: PropTypes.oneOfType([
-      PropTypes.arrayOf(React.PropTypes.node),
+      PropTypes.arrayOf(PropTypes.node),
       PropTypes.node,
     ]),
     onKeyDown: PropTypes.func,

--- a/src/js/components/header/header_menu.js
+++ b/src/js/components/header/header_menu.js
@@ -20,7 +20,7 @@ export default class HeaderMenu extends Component {
     items: PropTypes.array,
     onClick: PropTypes.func,
     children: PropTypes.oneOfType([
-      PropTypes.arrayOf(React.PropTypes.node),
+      PropTypes.arrayOf(PropTypes.node),
       PropTypes.node,
     ]),
   };

--- a/src/js/components/input/grid_form/input_grid_form.js
+++ b/src/js/components/input/grid_form/input_grid_form.js
@@ -20,7 +20,7 @@ export default class InputGridForm extends InputBase {
     fields: PropTypes.object,
     form: PropTypes.object,
     clientSide: PropTypes.bool,
-    clientSideIdField: React.PropTypes.string,
+    clientSideIdField: PropTypes.string,
     inputWrapperComponent: PropTypes.component,
     onSuccess: PropTypes.func,
     onDestroySuccess: PropTypes.func,

--- a/src/js/components/input/input_error.js
+++ b/src/js/components/input/input_error.js
@@ -7,7 +7,7 @@ import { CssClassMixin } from '../../mixins';
 @mixin(CssClassMixin)
 export default class InputError extends Component {
   static propTypes = {
-    errors: PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
+    errors: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   };
 
   static defaultProps = {

--- a/src/js/components/label/label.js
+++ b/src/js/components/label/label.js
@@ -12,7 +12,7 @@ export default class Label extends Component {
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     active: PropTypes.bool,
     onClick: PropTypes.func,
-    required: React.PropTypes.bool
+    required: PropTypes.bool
   };
 
   static defaultProps = {

--- a/src/js/components/link/link.js
+++ b/src/js/components/link/link.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from '../../prop_types';
 
 export const Link = (props) => (
   <a {...props}>{props.children}</a>
@@ -6,7 +7,7 @@ export const Link = (props) => (
 
 Link.propTypes = {
   children: PropTypes.oneOfType([
-    PropTypes.arrayOf(React.PropTypes.node),
+    PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]),
 };

--- a/src/js/components/menu/menu.js
+++ b/src/js/components/menu/menu.js
@@ -9,9 +9,9 @@ import MenuItem from './menu_item';
 export default class Menu extends Component {
   static propTypes = {
     id: PropTypes.string,
-    items: PropTypes.arrayOf(React.PropTypes.node),
+    items: PropTypes.arrayOf(PropTypes.node),
     children: PropTypes.oneOfType([
-      PropTypes.arrayOf(React.PropTypes.node),
+      PropTypes.arrayOf(PropTypes.node),
       PropTypes.node,
     ]),
   };

--- a/src/js/components/table/table_actions.js
+++ b/src/js/components/table/table_actions.js
@@ -10,7 +10,7 @@ import TableSelectionIndicator from './table_selection_indicator';
 export default class TableActions extends Component {
   static propTypes = {
     dataRows: PropTypes.array,
-    selectable: React.PropTypes.oneOf(['multiple', 'none', 'one']),
+    selectable: PropTypes.oneOf(['multiple', 'none', 'one']),
     selectedRowIds: PropTypes.array,
     selectedRowIdsParam: PropTypes.string,
     actionButtons: PropTypes.array,

--- a/src/js/components/table/table_row.js
+++ b/src/js/components/table/table_row.js
@@ -15,7 +15,7 @@ export default class TableRow extends Component {
     columns: PropTypes.object,
     data: PropTypes.object,
     dataRowIdField: PropTypes.string,
-    selectable: React.PropTypes.oneOf(['multiple', 'none', 'one']),
+    selectable: PropTypes.oneOf(['multiple', 'none', 'one']),
     selected: PropTypes.bool,
     actionButtons: PropTypes.array,
     rowSelectableFilter: PropTypes.func,

--- a/src/js/components/tabs/tab.js
+++ b/src/js/components/tabs/tab.js
@@ -13,7 +13,7 @@ import {
 )
 export default class Tab extends Component {
   static propTypes = {
-    id: React.PropTypes.string
+    id: PropTypes.string
   };
 
   render () {

--- a/src/js/mixins/form/form_container_mixin.js
+++ b/src/js/mixins/form/form_container_mixin.js
@@ -5,7 +5,7 @@ import themes from '../../theme';
 
 export default {
   propTypes: {
-    errors: PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
+    errors: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     errorThemeClassKey: PropTypes.string
   },
 

--- a/src/js/prop_types.js
+++ b/src/js/prop_types.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import PropTypes from 'prop-types';
 import i18n from './i18n/i18n';
 
 export default {
-  ...React.PropTypes,
+  ...PropTypes,
   localizedString(props, propName, componentName) {
     const value = props[propName];
     if (value === null ||
@@ -22,9 +22,9 @@ export default {
 
     return null;
   },
-  component: React.PropTypes.oneOfType([
-    React.PropTypes.func,
-    React.PropTypes.element,
-    React.PropTypes.string,
+  component: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.element,
+    PropTypes.string,
   ]),
 };


### PR DESCRIPTION
Algumas referências ao PropTypes estavam apontando para `React.PropTypes`, que foi deprecado em novas versões do React. Deve-se utilizar a biblioteca `prop-types` e refatorar componentes internos para utilizar o PropTypes do realize.